### PR TITLE
resync time when time zone is changed from the web page. Some typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SMPTE EB linear time cod generator.
+# SMPTE / EBU linear time code generator.
 
 ESP32 based SMPTE/EBU timecode generator, with NTP slaving, for Leitch and similar studio/broadcast clocks.
 

--- a/SMPTEGenerator/SMPTEGenerator.ino
+++ b/SMPTEGenerator/SMPTEGenerator.ino
@@ -19,7 +19,12 @@
 #include <ESPmDNS.h>
 #include <lwip/apps/sntp.h>
 
-#define VERSION "2.04"
+#define VERSION "2.05"
+
+// Set the WIFI network to connect to and the credentials
+// You **must** change these
+#define WIFI_NETWORK  "Your WIFI network"
+#define WIFI_PASSWD   "WIFI password"
 
 // The 'red' pin is wired through a 2k2 resistor to the base of an NPN
 // transistor. The latter its C is pulled up by a 1k resistor to the 5V taken

--- a/SMPTEGenerator/WebConfig.ino
+++ b/SMPTEGenerator/WebConfig.ino
@@ -50,7 +50,7 @@ void handleRoot(void)
                 String("Local time: ") + String(ctime(&now)) + String("<br>") +
                 String("Browser time: <span id='ts'>here</span><p>") +
                 String("<form method=post>") +
-                String("Current Timezone definition: <input name = 'tz' value = '") + String(tz) + String("' size = 40> timezone or a <a href = 'https://ublications.opengroup.org/c181'>POSIX TM definition string </a>.<br>") +
+                String("Current Timezone definition: <input name = 'tz' value = '") + String(tz) + String("' size = 40> timezone or a <a href = 'https://publications.opengroup.org/c181'>POSIX TM definition string </a>.<br>") +
                 String("Examples: <ul>") +
                 String("  <li>CET-1CEST,M3.5.0,M10.5.0/3") +
                 String("  <li>PST8PST") +
@@ -78,4 +78,5 @@ void handleRoot(void)
     return;
   }
   server.send(200, "textbrlain", "Ok, config stored.");
+  forceNTP();
 }

--- a/SMPTEGenerator/ntp.ino
+++ b/SMPTEGenerator/ntp.ino
@@ -83,8 +83,14 @@ int setAndWriteNtp(float fs, String _tz) {
   return setNtp(fs, _tz);
 }
 
+
+static time_t lastTime = 0;
+
+void forceNTP() {
+  lastTime = 0;
+}
+  
 bool ntp_loop() {
-  static time_t lastTime = 0;
   static bool needssetup = true;
 
   if (needssetup) {


### PR DESCRIPTION
When the user changes the timezone on the web interface, nothing happens to the clock until the next scheduled NTP sync. This may take up to 15 minutes.
This patch forces the 'lastTime' to be more than 15 minutes ago and so the NTP call will be triggered in the loop.

A few typos fixed.